### PR TITLE
Fixed example: add_rownames has been deprecated

### DIFF
--- a/ggradar.Rmd
+++ b/ggradar.Rmd
@@ -17,7 +17,7 @@ suppressPackageStartupMessages(library(dplyr))
 library(scales)
 
 mtcars %>%
-     add_rownames( var = "group" ) %>%
+     rownames_to_column( var = "group" ) %>%
      mutate_each(funs(rescale), -group) %>%
      tail(4) %>% select(1:10) -> mtcars_radar
 


### PR DESCRIPTION
The example uses a deprecated dplyr function (`add_rownames`) that will not run anymore in current versions. The tibble function `rownames_to_column()` should be used instead.